### PR TITLE
rounding in TT.normalise.sum

### DIFF
--- a/pkg/soiltexture/R/soiltexture.R
+++ b/pkg/soiltexture/R/soiltexture.R
@@ -7761,7 +7761,8 @@ TT.normalise.sum <- function(# Normalises the sum of the 3 particle size classes
     text.tol    = NULL, 
     #
     tri.pos.tst = NULL, 
-    residuals   = FALSE  
+    residuals   = FALSE,
+    digits      = NULL
 ){  #
     # Set rest of variables:
     TT.auto.set( set.par = FALSE ) 
@@ -7790,6 +7791,12 @@ TT.normalise.sum <- function(# Normalises the sum of the 3 particle size classes
             X * (text.sum/sum(X)) 
         }   #
     )   )   #
+    #
+      if(!is.null(digits))
+      {
+        tri.data <- round(tri.data,digits)
+        tri.data[,css.names[1]]<-100-apply(tri.data[,css.names[-1]],MARGIN = 1, sum)
+      }
     #
     if( class.ini == "data.frame" ) 
     {   #


### PR DESCRIPTION
add digits parameter (lines 7765 and 7794-7799) to set number of decimal digits in function output and keep sum normalized to 100%.

Due limited programming skills, the changes were only tested without building the package.
Additional changed lines were not intended (subject to new lines syntax)